### PR TITLE
Update core.yml

### DIFF
--- a/locale/core.yml
+++ b/locale/core.yml
@@ -142,7 +142,7 @@ core:
       display_name_heading: 用户外显名称
       display_name_text: 选择外显名称的类型，默认为用户名。
       forum_description_heading: 论坛描述
-      forum_description_text: '输入一两句话简单介绍您的论坛。这将会显示为 <meta name="description"> 描述标签，一般为 160 字的文本，用于介绍网页的内容。平常多被搜索引擎截取网页简介用。'
+      forum_description_text: '输入一两句简短的社区描述，该内容将被添加至页面的 meta 标签，并会出现在搜索引擎的结果里。'
       forum_title_heading: 论坛名称
       home_page_heading: 论坛首页
       home_page_text: 选择一种页面作为论坛首页。


### PR DESCRIPTION
The backend page is unavailable because the content in a description, specifically the "<meta>" brackets, was mistakenly interpreted as HTML and was not translated correctly.